### PR TITLE
Migrate from pyautogen to ag2 Library

### DIFF
--- a/docker/Dockerfile.magentic-one
+++ b/docker/Dockerfile.magentic-one
@@ -65,7 +65,7 @@ RUN . .venv/bin/activate && \
     opentelemetry-api==1.27.0 opentelemetry-exporter-otlp==1.27.0 \
     opentelemetry-instrumentation-fastapi==0.48b0 opentelemetry-instrumentation-logging==0.48b0 \
     opentelemetry-sdk==1.27.0 pandarallel prometheus-fastapi-instrumentator==7.0.0 prometheus_client \
-    pyautogen pydantic pyjwt[crypto]==2.9.0 python-multipart PyYAML typer uvicorn jinja2 \
+    ag2 pydantic pyjwt[crypto]==2.9.0 python-multipart PyYAML typer uvicorn jinja2 \
     autogen autogen-ext[openai]==0.4.0.dev6 && \
     cd /home/${USER}/autogen/python/packages/autogen-magentic-one && \
     pip install -e .


### PR DESCRIPTION
Hey there! This is AG2 👋

First of all, thank you for using pyautogen! We've seen you're using pyautogen, and we're here to help you migrate to ag2.

This pull request is designed to help update this codebase by smoothly transitioning from the `pyautogen` library to the new `ag2` library.

Why the change? `pyautogen` is being deprecated, and `ag2` is now the recommended successor for ongoing development. 

The good news is, **there is no syntax difference between pyautogen and ag2** – this migration primarily involves updating library imports and usage.

This update will ensure the project stays compatible with the latest tools and can benefit from all the improvements in the ag2 ecosystem.

Could you please take a moment to review and merge this at your earliest convenience? Your collaboration is much appreciated! Thank you!
